### PR TITLE
add netdata demo site

### DIFF
--- a/group_vars/all/vars
+++ b/group_vars/all/vars
@@ -27,6 +27,21 @@ prometheus_targets:
       - "{{ ansible_host }}:8080"
       labels:
         env: demo
+  netdata:
+    - targets:
+      - "london.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      - "atlanta.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      - "sanfrancisco.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      - "toronto.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      - "bangalore.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      - "singapore.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      - "newyork.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      - "frankfurt.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      - "octopuscs.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      - "ventureer.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      - "stackscale.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      labels:
+        env: netdata-demo
 
 prometheus_scrape_configs:
 - job_name: "prometheus"
@@ -69,6 +84,11 @@ prometheus_scrape_configs:
       target_label: instance
     - target_label: __address__
       replacement: 127.0.0.1:9115  # Blackbox exporter.
+- job_name: "netdata"
+  scrape_interval: 30s
+  file_sd_configs:
+  - files:
+    - "/etc/prometheus/file_sd/netdata.yml"
 
 alertmanager_external_url: "http://{{ ansible_host }}:9093"
 alertmanager_slack_api_url: "http://example.org"

--- a/group_vars/all/vars
+++ b/group_vars/all/vars
@@ -29,17 +29,17 @@ prometheus_targets:
         env: demo
   netdata:
     - targets:
-      - "london.my-netdata.io/api/v1/allmetrics?format=prometheus"
-      - "atlanta.my-netdata.io/api/v1/allmetrics?format=prometheus"
-      - "sanfrancisco.my-netdata.io/api/v1/allmetrics?format=prometheus"
-      - "toronto.my-netdata.io/api/v1/allmetrics?format=prometheus"
-      - "bangalore.my-netdata.io/api/v1/allmetrics?format=prometheus"
-      - "singapore.my-netdata.io/api/v1/allmetrics?format=prometheus"
-      - "newyork.my-netdata.io/api/v1/allmetrics?format=prometheus"
-      - "frankfurt.my-netdata.io/api/v1/allmetrics?format=prometheus"
-      - "octopuscs.my-netdata.io/api/v1/allmetrics?format=prometheus"
-      - "ventureer.my-netdata.io/api/v1/allmetrics?format=prometheus"
-      - "stackscale.my-netdata.io/api/v1/allmetrics?format=prometheus"
+      - "london.my-netdata.io"
+      - "atlanta.my-netdata.io"
+      - "sanfrancisco.my-netdata.io"
+      - "toronto.my-netdata.io"
+      - "bangalore.my-netdata.io"
+      - "singapore.my-netdata.io"
+      - "newyork.my-netdata.io"
+      - "frankfurt.my-netdata.io"
+      - "octopuscs.my-netdata.io"
+      - "ventureer.my-netdata.io"
+      - "stackscale.my-netdata.io"
       labels:
         env: netdata-demo
 
@@ -85,7 +85,8 @@ prometheus_scrape_configs:
     - target_label: __address__
       replacement: 127.0.0.1:9115  # Blackbox exporter.
 - job_name: "netdata"
-  scrape_interval: 30s
+  scrape_interval: 60s
+  metrics_path: "/api/v1/allmetrics?format=prometheus"
   file_sd_configs:
   - files:
     - "/etc/prometheus/file_sd/netdata.yml"


### PR DESCRIPTION
This PR will cause prometheus to scrape every server from [my-netdata.io](http://my-netdata.io) demo sites every 60 seconds.
Basically it is a demo of [this tutorial](https://github.com/firehol/netdata/wiki/Netdata,-Prometheus,-and-Grafana-Stack).

@ktsaou can I connect cloudalchemy demo site with my-netdata.io ?