### PR TITLE
prometheus: bump retention to 31d

### DIFF
--- a/group_vars/all/vars
+++ b/group_vars/all/vars
@@ -1,6 +1,6 @@
 ---
 prometheus_web_external_url: "http://{{ ansible_host }}:9090"
-prometheus_storage_retention: "14d"
+prometheus_storage_retention: "31d"
 
 prometheus_alertmanager_config:
   - scheme: http


### PR DESCRIPTION
This extends Prometheus retention to keep one month worth of data.

Signed-off-by: Luca Bruno <luca.bruno@coreos.com>